### PR TITLE
Optimize fpadd/fpsub and normalization helpers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Check
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   check:
@@ -12,7 +12,7 @@ jobs:
         offset: [1, 2]
         include:
           - runs-on: ubuntu
-            make-args: CC=clang-11 CXX=clang++-11 LDFLAGS=-fuse-ld=lld
+            make-args: CC=clang-12 CXX=clang++-12 LDFLAGS=-fuse-ld=lld
             begin: 1
             end: 2
           - runs-on: macos

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
         offset: [1, 2]
         include:
           - runs-on: ubuntu
-            make-args: CC=clang-13 CXX=clang++-13 LDFLAGS=-fuse-ld=lld
+            make-args: CC=clang-16 CXX=clang++-16 LDFLAGS=-fuse-ld=lld
             begin: 1
             end: 2
           - runs-on: macos

--- a/src/fpaddsub.inc
+++ b/src/fpaddsub.inc
@@ -174,6 +174,8 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	neg
 	sbc	hl, de
 	jq	c, .borrow
+	jq	nz, .done
+	ld	c, l
 .done:
 	dec	b
 .done2:

--- a/src/fpaddsub.inc
+++ b/src/fpaddsub.inc
@@ -45,25 +45,71 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 .sorted:
 	cp	a, 26
 	jq	nc, .largest
-	push	hl
+	; Extend to 32 bits and shift left by ~(amount - 1) & 7
+	dec	a
 	ld	b, a
 	xor	a, a
-	sbc	hl, hl
-	add	hl, sp
-.shift:
-	inc	hl
-	inc	hl
-	srl	(hl)
-	dec	hl
-	rr	(hl)
-	dec	hl
-	rr	(hl)
-	rra
-	jq	nc, .flushed1
-	or	a, b
-.flushed1:
-	djnz	.shift
+	srl	b
+	jq	c, .noshift1
+	add	hl, hl
+	rla
+.noshift1:
+	srl	b
+	jq	c, .noshift2
+	repeat	2
+	add	hl, hl
+	rla
+	end repeat
+.noshift2:
+	srl	b
+	jq	c, .noshift4
+	repeat	4
+	add	hl, hl
+	rla
+	end repeat
+.noshift4:
+	; Shift right by (amount + 7) / 8 * 8, truncating to 24 bits
+	; The last 2 bits shifted out are in A, while any remaining non-zero
+	; bits are aggregated into the lower bits of A
+	push	af
+	inc	sp
+	push	hl
+	inc	sp
+	jq	nz, .noshift8
+	; Shift by 8 for amounts between 1 and 8
+	ld	a, l
 	pop	hl
+	inc	sp
+	jq	.rounded
+
+.noshift8:
+	inc	sp
+	xor	a, a
+	cp	a, l
+	rla
+	djnz	.noshift16
+	; Shift by 16 for amounts between 9 and 16
+	or	a, h
+	pop	hl
+	jq	.rounded
+
+.noshift24:
+	; Shift by 32 for amount of 25
+	cp	a, l
+	rla
+	or	a, h
+	sbc	hl, hl
+	jq	.rounded
+
+.noshift16:
+	cp	a, h
+	rla
+	pop	hl
+	djnz	.noshift24
+	; Shift by 24 for amounts between 17 and 24
+	or	a, l
+	ld	l, h
+	ld	h, b ;0
 .rounded:
 	ld	b, d
 	pop	de
@@ -75,6 +121,37 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	ld	c, l
 	pop	hl
 	jq	.subtract
+
+.nonfinite1:
+	inc	d
+	jq	z, .nonfinite
+.return1:
+	pop	bc
+.return1.pop1:
+	pop	de
+	ld	a, d
+.return1.pop2:
+	xor	a, e
+	pop	bc
+.return:
+	pop	hl
+	pop	de
+	ret
+
+.largest:
+	ld	a, d
+	cp	a, e
+	jq	z, .return1
+.return2:
+	pop	bc
+.return2.pop1:
+	pop	de
+.return2.pop2:
+	ld	a, e
+	pop	bc
+	pop	bc
+	push	bc
+	jq	.return
 
 .add:
 	ld	c, h
@@ -115,37 +192,6 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	pop	bc
 	pop	de
 	ret
-
-.nonfinite1:
-	inc	d
-	jq	z, .nonfinite
-.return1:
-	pop	bc
-.return1.pop1:
-	pop	de
-	ld	a, d
-.return1.pop2:
-	xor	a, e
-	pop	bc
-.return:
-	pop	hl
-	pop	de
-	ret
-
-.largest:
-	ld	a, d
-	cp	a, e
-	jq	z, .return1
-.return2:
-	pop	bc
-.return2.pop1:
-	pop	de
-.return2.pop2:
-	ld	a, e
-	pop	bc
-	pop	bc
-	push	bc
-	jq	.return
 
 .nonfinite:
 	xor	a, a

--- a/src/fpaddsub.inc
+++ b/src/fpaddsub.inc
@@ -176,6 +176,8 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	neg
 	sbc	hl, de
 	jq	c, .borrow
+	jq	nz, .done
+	or	a, a
 .done:
 	ld	de, 0800000h
 	call	nz, __fppack

--- a/src/fpaddsub.inc
+++ b/src/fpaddsub.inc
@@ -75,41 +75,33 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	inc	sp
 	push	hl
 	inc	sp
-	jq	nz, .noshift8
-	; Shift by 8 for amounts between 1 and 8
 	ld	a, l
+	jq	nz, .shift16
+	; Shift by 8 for amounts between 1 and 8
 	pop	hl
 	inc	sp
 	jq	.rounded
 
-.noshift8:
-	inc	sp
-	xor	a, a
-	cp	a, l
-	rla
-	djnz	.noshift16
+.shift16:
 	; Shift by 16 for amounts between 9 and 16
-	or	a, h
+	ld	e, h
+	inc	sp
 	pop	hl
-	jq	.rounded
-
-.noshift24:
-	; Shift by 32 for amount of 25
-	cp	a, l
-	rla
-	or	a, h
-	sbc	hl, hl
-	jq	.rounded
-
-.noshift16:
-	cp	a, h
-	rla
-	pop	hl
-	djnz	.noshift24
+	dec	b
+	jq	z, .flush
+.shift8more:
 	; Shift by 24 for amounts between 17 and 24
-	or	a, l
+	or	a, e
+	ld	e, l
 	ld	l, h
-	ld	h, b ;0
+	ld	h, 0
+	; Shift by 32 for amount of 25
+	djnz	.shift8more
+.flush:
+	sub	a, 1
+	sbc	a, a
+	inc	a
+	or	a, e
 .rounded:
 	ld	b, d
 	pop	de

--- a/src/fpaddsub.inc
+++ b/src/fpaddsub.inc
@@ -33,8 +33,6 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	jq	z, .nonfinite1
 	inc	d
 	jq	z, .return2
-	dec	e
-	dec	d
 	ld	a, d
 	sub	a, e
 	jq	z, .rounded
@@ -70,23 +68,23 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	ld	b, d
 	pop	de
 	ex	(sp), hl
-	bit	7, h
-	jq	nz, .willsubtract
-	ld	c, 0
-.willsubtract:
-	bit	7, l
-	jq	z, .positive
-	inc	c
-.positive:
-	bit	7, h
+	add.s	hl, hl
+	jq	nc, .add
+	ld	l, h
+	add	hl, bc
+	ld	c, l
 	pop	hl
-	jq	nz, .subtract
+	jq	.subtract
+
+.add:
+	ld	c, h
+	pop	hl
 	add	hl, de
 	jq	nc, .done
-	push	hl
-	ld	hl, 2
+	ex	de, hl
+	sbc	hl, hl
 	add	hl, sp
-	scf
+	push	de
 	rr	(hl)
 	pop	hl
 	rr	h
@@ -96,19 +94,20 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	or	a, 1
 .flushed2:
 	inc	b
-	inc	b
 	jq	z, .infinite
-	dec	b
-	jq	.done
+	djnz	.done2	;always taken
+
 .borrow:
+	inc	c
 	add	hl, de
+.subtract:
 	ex	de, hl
 	neg
-.subtract:
-	inc	c
 	sbc	hl, de
 	jq	c, .borrow
 .done:
+	dec	b
+.done2:
 	ld	de, 0800000h
 	call	__fppack
 	pop	bc
@@ -116,6 +115,7 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	pop	bc
 	pop	de
 	ret
+
 .nonfinite1:
 	inc	d
 	jq	z, .nonfinite
@@ -131,6 +131,7 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	pop	hl
 	pop	de
 	ret
+
 .largest:
 	ld	a, d
 	cp	a, e
@@ -145,29 +146,24 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	pop	bc
 	push	bc
 	jq	.return
-.infinite:
-	ld	a, c
-	pop	bc
-	pop	hl
-	pop	de
-	rrca
-	or	a, 07Fh
-	ld	bc, 0800000h
-	ret
+
 .nonfinite:
 	xor	a, a
 	sbc	hl, bc
 	jq	nz, .return1
 	pop	hl
-;	or	a, a
 	sbc	hl, bc
 	jq	nz, .return2.pop1
 	pop	de
 	bit	7, d
 	jq	z, .return1.pop2
-	pop	bc
+	ld	bc, 0C00000h
+.infinite:
+	ld	a, c
+	ld	c, b ;0, also note BCU=080h from __fpupop1 or 0C0h from .nonfinite
+	rrca
+	or	a, 07Fh
+	pop	hl
 	pop	hl
 	pop	de
-	ld	a, 07Fh
-	ld	bc, 0C00000h
 	ret

--- a/src/fpaddsub.inc
+++ b/src/fpaddsub.inc
@@ -112,7 +112,7 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	add	hl, bc
 	ld	c, l
 	pop	hl
-	jq	.subtract
+	djnz	.subtract	;always taken
 
 .nonfinite1:
 	inc	d
@@ -149,6 +149,7 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	ld	c, h
 	pop	hl
 	add	hl, de
+	dec	b
 	jq	nc, .done
 	ex	de, hl
 	sbc	hl, hl
@@ -163,8 +164,9 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	or	a, 1
 .flushed2:
 	inc	b
+	inc	b
 	jq	z, .infinite
-	djnz	.done2	;always taken
+	djnz	.done	;always taken
 
 .borrow:
 	inc	c
@@ -174,13 +176,9 @@ __fpadd: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	neg
 	sbc	hl, de
 	jq	c, .borrow
-	jq	nz, .done
-	ld	c, l
 .done:
-	dec	b
-.done2:
 	ld	de, 0800000h
-	call	__fppack
+	call	nz, __fppack
 	pop	bc
 	ex	(sp), hl
 	pop	bc

--- a/src/fpcbrt.inc
+++ b/src/fpcbrt.inc
@@ -1,0 +1,181 @@
+; IEEE single precision cube root
+; aubc = cbrt(aubc)
+__fpcbrt: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), (float)cbrt(bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	de, bc
+	ex	(sp), hl
+	ld	e, a
+	call	__fpupop1
+	inc	e
+	jq	z, .nonfinite
+	dec	e
+	ld	d, 0ABh	; multiplicative inverse of 3 modulo 256
+	ld	b, d
+	mlt	de
+	ld	c, a
+	ld	a, i
+	push	af, hl
+	ex	(sp), ix
+	or	a, a
+	sbc	hl, hl
+	ld	a, e
+	ld	d, 10	; maximum normalization iterations to determine a zero
+.modulo.loop:
+	; x <<= 1
+	add	ix, ix
+	adc	hl, hl
+	sub	a, b
+	jq	c, .modulo.loop
+	jq	nz, .normalized
+	dec	d
+	jq	z, .return
+	cp	a, l
+	inc	a
+	jq	nc, .modulo.loop
+.normalized:
+	add	a, d
+	ld	b, a
+	push	bc
+	xor	a, a
+	ld	d, a
+	ld	e, a
+	push	de
+	ex	(sp), iy
+	di
+	exx
+	ld	c, a
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
+	ld	b, 24
+	; x in AUHL[UHL']UIX, r in CUDE[UDE'], q in UIY
+.root.loop:
+	exx
+	; q <<= 1
+	add	iy, iy	; clears carry
+	lea	bc, iy
+	; r += 1
+	inc	de	; sets bit 0 so never overflows
+	; x -= r << 24
+	sbc	hl, de
+	exx
+	sbc	hl, de
+	sbc	a, c
+	exx
+	jq	c, .root.zerobit
+	ex	af, af'
+	; q += 1
+	inc	iy
+	; r += q * 4 - 1
+	ex	de, hl
+	xor	a, a
+	add	hl, bc
+	rla
+	inc	bc
+	repeat	3
+	add	hl, bc
+	adc	a, 0
+	end repeat
+	; r <<= 2
+	add	hl, hl
+	rla
+	; r += q
+	add	hl, bc
+	adc	a, 0
+	jq	.root.nextbit
+.root.zerobit:
+	; x += r << 24
+	add	hl, de
+	exx
+	adc	hl, de
+	adc	a, c
+	exx
+	ex	af, af'
+	; r -= q + 1
+	ex	de, hl
+	scf
+	sbc	hl, bc
+	sbc	a, a
+	; r <<= 1
+	add	hl, hl
+	rla
+	; r -= q
+	or	a, a
+	sbc	hl, bc
+	sbc	a, 0
+.root.nextbit:
+	; r <<= 1
+	add	hl, hl
+	rla
+	ex	de, hl
+	exx
+	push	hl
+	; Sign extend carry byte to 32 bits
+	sbc	hl, hl
+	ld	l, a
+	sbc	a, a
+	; Left shift high 32 bits of r by 2
+	ex	de, hl
+	repeat	2
+	add	hl, hl
+	rl	c
+	end repeat
+	; Add carry byte to shifted high bits
+	add	hl, de
+	ex	de, hl
+	adc	a, c
+	ld	c, a
+	pop	hl
+	exx
+	; x <<= 3
+	xor	a, a
+	repeat	3
+	add	ix, ix
+	adc	hl, hl
+	rla
+	end repeat
+	exx
+	ex	af, af'
+	repeat	3
+	add	hl, hl
+	rla
+	end repeat
+	ex	af, af'
+	or	a, l
+	ld	l, a
+	ex	af, af'
+	djnz	.root.loop
+	; Determine rounding direction
+	exx
+	; x -= (r + (~q & 1)) << 24
+	srl	c	; q still in UBC from the last iteration
+	ccf
+	sbc	hl, de
+	exx
+	sbc	hl, de
+	sbc	a, c
+	; q += !carry
+	sbc	hl, hl
+	inc	hl
+	ex	(sp), iy
+	pop	bc
+	add	hl, bc
+	pop	bc
+	; Get final exponent after rounding
+	ld	a, b
+	adc	a, 07Fh - (07Fh / 3) - 10
+	; Set low exponent bit
+	srl	b
+	jq	nc, .return
+	ld	de, 0800000h
+	add	hl, de
+.return:
+	sla	c
+	rra
+	pop	ix, bc
+	bit	2, c
+.nonfinite:
+	ex	(sp), hl
+	pop	bc, de
+	ret	z
+	ei
+	ret

--- a/src/fpcbrt.inc
+++ b/src/fpcbrt.inc
@@ -40,6 +40,11 @@ __fpcbrt: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), (float)cb
 	ld	e, a
 	push	de
 	ex	(sp), iy
+	; Optimized first iteration, we know UHL >= 1
+	; r += 1
+	inc	de
+	; x -= r << 24
+	dec	hl
 	di
 	exx
 	ld	c, a
@@ -50,17 +55,7 @@ __fpcbrt: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), (float)cb
 	; x in AUHL[UHL']UIX, r in CUDE[UDE'], q in UIY
 .root.loop:
 	exx
-	; q <<= 1
-	add	iy, iy	; clears carry
 	lea	bc, iy
-	; r += 1
-	inc	de	; sets bit 0 so never overflows
-	; x -= r << 24
-	sbc	hl, de
-	exx
-	sbc	hl, de
-	sbc	a, c
-	exx
 	jq	c, .root.zerobit
 	ex	af, af'
 	; q += 1
@@ -143,23 +138,24 @@ __fpcbrt: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), (float)cb
 	or	a, l
 	ld	l, a
 	ex	af, af'
-	djnz	.root.loop
-	; Determine rounding direction
 	exx
-	; x -= (r + (~q & 1)) << 24
-	srl	c	; q still in UBC from the last iteration
-	ccf
+	; q <<= 1
+	add	iy, iy	; clears carry
+	; r += 1
+	inc	de	; sets bit 0 so never overflows
+	; x -= r << 24
 	sbc	hl, de
 	exx
 	sbc	hl, de
 	sbc	a, c
+	djnz	.root.loop
+	; Apply rounding (never round-to-even because a root with the lowest mantissa bit set must be irrational)
 	; q += !carry
+	exx
 	sbc	hl, hl
 	inc	hl
-	ex	(sp), iy
-	pop	bc
 	add	hl, bc
-	pop	bc
+	pop	iy, bc
 	; Get final exponent after rounding
 	ld	a, b
 	adc	a, 07Fh - (07Fh / 3) - 10

--- a/src/fpcmp.inc
+++ b/src/fpcmp.inc
@@ -133,40 +133,38 @@ __fpcmpo: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) =
 ; z = euhl == aubc
 ; s = euhl < aubc = !(euhl >= aubc)
 __fpcmp: ; CHECK: (isunordered(bitcast(float, pair8_24_t, { in.HL, in.E }), bitcast(float, pair8_24_t, { in.BC, in.A })) || (out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) == bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.S == (bitcast(float, pair8_24_t, { in.HL, in.E }) < bitcast(float, pair8_24_t, { in.BC, in.A })))) && out.A == in.A && out.BC == in.BC && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
-	cp	a, e
+	sub	a, e
 	jq	z, .maybeEqual
-	add	a, a
-	rra
+	cp	a, 080h
 	jq	z, .maybeBothZero
 	; Compare sign and upper 7 exponent bits, which are not equal
-	cp	a, e
+	add	a, e
 	inc	e
 	dec	e	; S = sign(euhl), Z = 0 because E > A
 	ret	c
-	cp	a, 080h	; S = !sign(aubc), Z = 0 because A != 080h
+.notBothZero:
+	cp	a, 080h	; S = !sign(aubc)
+	ret	nz
+	cp	a, e ; S = !sign(aubc), Z = 0 because A == 080h and A > E and A - E != 080h
 	ret
 
 .maybeBothZero:
-	xor	a, e
-	cp	a, 080h
+	add	a, e
+	add	a, a
+	rra
 	jq	nz, .notBothZero
-	xor	a, e
 	adc	hl, bc
 	jq	c, .notBothZeroFixup
 	ret	z	; Both inputs are zero, return Z=1, S=0
 .notBothZeroFixup:
-	xor	a, e
+	or	a, a
 	sbc	hl, bc
-.notBothZero:
-	xor	a, e
-	cp	a, e
-	inc	e
-	dec	e	; S = sign(euhl), Z = 0 because E > A
-	ret	c
-	cp	a, 07Fh	; S = !sign(aubc), Z = 0 because (A & 07Fh) == 0
+	dec	a	; S = !sign(aubc), Z = 0 because (A & 07Fh) == 0
+	cpl	; Restore A, preserve S and Z
 	ret
 
 .maybeEqual:
+	ld	a, e
 	sbc	hl, bc
 	add	hl, bc
 	ret	z

--- a/src/fpcmp.inc
+++ b/src/fpcmp.inc
@@ -1,19 +1,19 @@
-; IEEE single precision comparison with unordered checks
+; IEEE single precision unordered comparison
 ; z = euhl == aubc || isunordered(euhl, aubc)
 ; c = !isunordered(euhl, aubc)
 __fpcmpu: ; CHECK: out.flags.C == !isunordered(bitcast(float, pair8_24_t, { in.HL, in.E }), bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.Z == (!out.flags.C || (bitcast(float, pair8_24_t, { in.HL, in.E }) == bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.A == in.A && out.BC == in.BC && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
-	call	__fpcmp
+	call	__fpcmpo
 	ret	c	; If euhl < aubc: C = 1, Z = 0
 	scf
 	ret	p	; If euhl >= aubc: C = 1, Z = (euhl == aubc)
 	cp	a, a	; If unordered: C = 0, Z = 1
 	ret
 
-; IEEE single precision comparison
+; IEEE single precision ordered comparison
 ; z = euhl == aubc
 ; c = euhl < aubc
 ; s = !(euhl >= aubc)
-__fpcmp: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) == bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.C == (bitcast(float, pair8_24_t, { in.HL, in.E }) < bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.S == !(bitcast(float, pair8_24_t, { in.HL, in.E }) >= bitcast(float, pair8_24_t, { in.BC, in.A })) && out.A == in.A && out.BC == in.BC && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+__fpcmpo: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) == bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.C == (bitcast(float, pair8_24_t, { in.HL, in.E }) < bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.S == !(bitcast(float, pair8_24_t, { in.HL, in.E }) >= bitcast(float, pair8_24_t, { in.BC, in.A })) && out.A == in.A && out.BC == in.BC && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
 	xor	a, e
 	jq	z, .maybeEqual
 	cp	a, 080h
@@ -127,4 +127,52 @@ __fpcmp: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) ==
 	rr	a ; Z = 0, S = 1
 	rla	; Restore A
 	ccf	; C = 0
+	ret
+
+; IEEE single precision comparison (flag outputs for NaN inputs are undefined)
+; z = euhl == aubc
+; s = euhl < aubc = !(euhl >= aubc)
+__fpcmp: ; CHECK: (isunordered(bitcast(float, pair8_24_t, { in.HL, in.E }), bitcast(float, pair8_24_t, { in.BC, in.A })) || (out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) == bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.S == (bitcast(float, pair8_24_t, { in.HL, in.E }) < bitcast(float, pair8_24_t, { in.BC, in.A })))) && out.A == in.A && out.BC == in.BC && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	cp	a, e
+	jq	z, .maybeEqual
+	add	a, a
+	rra
+	jq	z, .maybeBothZero
+	; Compare sign and upper 7 exponent bits, which are not equal
+	cp	a, e
+	inc	e
+	dec	e	; S = sign(euhl), Z = 0 because E > A
+	ret	c
+	cp	a, 080h	; S = !sign(aubc), Z = 0 because A != 080h
+	ret
+
+.maybeBothZero:
+	xor	a, e
+	cp	a, 080h
+	jq	nz, .notBothZero
+	xor	a, e
+	adc	hl, bc
+	jq	c, .notBothZeroFixup
+	ret	z	; Both inputs are zero, return Z=1, S=0
+.notBothZeroFixup:
+	xor	a, e
+	sbc	hl, bc
+.notBothZero:
+	xor	a, e
+	cp	a, e
+	inc	e
+	dec	e	; S = sign(euhl), Z = 0 because E > A
+	ret	c
+	cp	a, 07Fh	; S = !sign(aubc), Z = 0 because (A & 07Fh) == 0
+	ret
+
+.maybeEqual:
+	sbc	hl, bc
+	add	hl, bc
+	ret	z
+	; XOR the carry with the input sign and place into the output sign
+	sbc	a, a
+	xor	a, e
+	or	a, 07Fh ; Affect S flag, Z = 0
+	ld	a, e
 	ret

--- a/src/fpcmp.inc
+++ b/src/fpcmp.inc
@@ -1,3 +1,14 @@
+; IEEE single precision comparison with unordered checks
+; z = euhl == aubc || isunordered(euhl, aubc)
+; c = !isunordered(euhl, aubc)
+__fpcmpu: ; CHECK: out.flags.C == !isunordered(bitcast(float, pair8_24_t, { in.HL, in.E }), bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.Z == (!out.flags.C || (bitcast(float, pair8_24_t, { in.HL, in.E }) == bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.A == in.A && out.BC == in.BC && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	call	__fpcmp
+	ret	c	; If euhl < aubc: C = 1, Z = 0
+	scf
+	ret	p	; If euhl >= aubc: C = 1, Z = (euhl == aubc)
+	cp	a, a	; If unordered: C = 0, Z = 1
+	ret
+
 ; IEEE single precision comparison
 ; z = euhl == aubc
 ; c = euhl < aubc

--- a/src/fpcmp.inc
+++ b/src/fpcmp.inc
@@ -5,39 +5,25 @@
 __fpcmp: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) == bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.C == (bitcast(float, pair8_24_t, { in.HL, in.E }) < bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.S == !(bitcast(float, pair8_24_t, { in.HL, in.E }) >= bitcast(float, pair8_24_t, { in.BC, in.A })) && out.A == in.A && out.BC == in.BC && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
 	xor	a, e
 	jq	z, .maybeEqual
-	cp	a, 80h
+	cp	a, 080h
 	jq	c, .signsMatch
-	jq	nz, .notBothZero
-	xor	a, e
 	jq	z, .maybeBothZero
-	inc	e
-	dec	e
-	jq	nz, .notBothZero2
-.maybeBothZero:
-	adc	hl, bc
-	jq	nz, .notBothZeroFixup
-	ret	nc	; Both inputs are zero, return Z=1, C=0, S=0
-.notBothZeroFixup:
 	xor	a, e
-	sbc	hl, bc
-.notBothZero:
-	xor	a, e
-.notBothZero2:
+	; Check if first operand could hold NaN, and if so, the second cannot on this code path
 	inc	e
-	call	z, .checkFirstNan
-	call	pe, .checkFirstNan
+	jq	z, .checkFirstNan
+	jq	pe, .checkFirstNan
 	dec	e
 .secondLargerAbs:
-	cp	a, 0FFh
-	jq	z, .checkSecondNan
-	cp	a, 07Fh
-	ret	nz	; C = S = !sign(aubc), Z = 0
+	cp	a, 07Fh	; C = S = !sign(aubc), Z = 0
+	ret	c	; Return if A less than 07Fh
+	ret	pe	; Return if A between 080h and 0FEh
 .checkSecondNan:
 	push	hl
 	ld	hl, 07FFFFFh
 	add	hl, bc
 	pop	hl
-	jq	c, .outputNan
+	jq	c, .unordered
 	cp	a, 080h	; C = S = !sign(aubc), Z = 0
 	ret
 
@@ -47,12 +33,50 @@ __fpcmp: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) ==
 	cp	a, e
 	jq	nc, .secondLargerAbs
 	inc	e
-	call	z, .checkFirstNan
-	call	pe, .checkFirstNan
+	jq	z, .checkFirstNan
 	dec	e	; S = sign(euhl), Z = 0 because E > A
 	rlca
-	rrca		; C = sign(aubc)
+	rrca		; C = sign(aubc), same as sign(euhl) on this code path
+	ret	po	; Return if E != 07Fh
+.checkFirstNanInc:
+	inc	e
+.checkFirstNan:
+	ex	de, hl
+	push	hl
+	ld	hl, 07FFFFFh
+	add	hl, de
+	pop	hl
+	ex	de, hl
+	dec	e	; S = sign(euhl), Z = 0 because (E & 07Fh) == 07Fh
+	jq	c, .unordered
+	ret	p	; C = sign(euhl)
+	scf	; C = sign(euhl)
 	ret
+
+.maybeBothZero:
+	; Upper 7 bits of exponents are equal, but sign differs
+	xor	a, e
+	; Check if upper 7 bits of both exponents are zero
+	add	a, a
+	rra
+	jq	nz, .notBothZero
+	; Check if low bit of both exponents and entire mantissas are 0
+	adc	hl, bc
+	jq	nz, .notBothZeroFixup
+	ret	nc	; Both inputs are zero, return Z=1, C=0, S=0
+.notBothZeroFixup:
+	or	a, a
+	sbc	hl, bc
+.notBothZero:
+	; Check if upper 7 bits of both exponents are one
+	cp	a, 07Fh	; C = S = !sign(aubc), Z = 0
+	ret	c	; Return if less than 07Fh
+	ret	pe	; Return if between 080h and 0FEh
+	; Check the larger exponent/mantissa for NaN
+	sbc	hl, bc
+	add	hl, bc
+	jq	nc, .checkFirstNanInc
+	jq	.checkSecondNan
 
 .maybeEqual:
 	; Sign and upper 7 exponent bits are equal
@@ -75,25 +99,6 @@ __fpcmp: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) ==
 	ld	a, e
 	ret
 
-.checkFirstNan:
-	ex	de, hl
-	push	hl
-	ld	hl, 07FFFFFh
-	add	hl, de
-	pop	hl
-	ex	de, hl
-	ret	nc
-	dec	e
-	inc	sp
-	inc	sp
-	inc	sp
-.outputNan:
-	; Carry is always set here
-	rr	a ; Z = 0, S = 1
-	rla	; Restore A
-	ccf	; C = 0
-	ret
-
 .checkBothNan:
 	ex	de, hl
 	push	hl
@@ -106,4 +111,9 @@ __fpcmp: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) ==
 	pop	hl
 	ex	de, hl
 	jq	nc, .checkBothNanDone
-	jq	.outputNan
+.unordered:
+	; Carry is always set here
+	rr	a ; Z = 0, S = 1
+	rla	; Restore A
+	ccf	; C = 0
+	ret

--- a/src/fpcmp.inc
+++ b/src/fpcmp.inc
@@ -1,0 +1,109 @@
+; IEEE single precision comparison
+; z = euhl == aubc
+; c = euhl < aubc
+; s = !(euhl >= aubc)
+__fpcmp: ; CHECK: out.flags.Z == (bitcast(float, pair8_24_t, { in.HL, in.E }) == bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.C == (bitcast(float, pair8_24_t, { in.HL, in.E }) < bitcast(float, pair8_24_t, { in.BC, in.A })) && out.flags.S == !(bitcast(float, pair8_24_t, { in.HL, in.E }) >= bitcast(float, pair8_24_t, { in.BC, in.A })) && out.A == in.A && out.BC == in.BC && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	xor	a, e
+	jq	z, .maybeEqual
+	cp	a, 80h
+	jq	c, .signsMatch
+	jq	nz, .notBothZero
+	xor	a, e
+	jq	z, .maybeBothZero
+	inc	e
+	dec	e
+	jq	nz, .notBothZero2
+.maybeBothZero:
+	adc	hl, bc
+	jq	nz, .notBothZeroFixup
+	ret	nc	; Both inputs are zero, return Z=1, C=0, S=0
+.notBothZeroFixup:
+	xor	a, e
+	sbc	hl, bc
+.notBothZero:
+	xor	a, e
+.notBothZero2:
+	inc	e
+	call	z, .checkFirstNan
+	call	pe, .checkFirstNan
+	dec	e
+.secondLargerAbs:
+	cp	a, 0FFh
+	jq	z, .checkSecondNan
+	cp	a, 07Fh
+	ret	nz	; C = S = !sign(aubc), Z = 0
+.checkSecondNan:
+	push	hl
+	ld	hl, 07FFFFFh
+	add	hl, bc
+	pop	hl
+	jq	c, .outputNan
+	cp	a, 080h	; C = S = !sign(aubc), Z = 0
+	ret
+
+.signsMatch:
+	xor	a, e
+	; Compare upper 7 exponent bits, which are not equal
+	cp	a, e
+	jq	nc, .secondLargerAbs
+	inc	e
+	call	z, .checkFirstNan
+	call	pe, .checkFirstNan
+	dec	e	; S = sign(euhl), Z = 0 because E > A
+	rlca
+	rrca		; C = sign(aubc)
+	ret
+
+.maybeEqual:
+	; Sign and upper 7 exponent bits are equal
+	ld	a, e
+	inc	a
+	add	a, a
+	ld	a, e
+	jq	z, .checkBothNan
+	or	a, a
+.checkBothNanDone:
+	; Compare mantissas and low exponent bit
+	sbc	hl, bc
+	add	hl, bc
+	ret	z	; Both inputs are equal, return Z=1, C=0, S=0
+	; XOR the carry with the input sign and place into the output sign/carry
+	sbc	a, a
+	xor	a, e
+	or	a, 07Fh ; Affect S flag, Z = 0
+	rlca	; Affect C flag
+	ld	a, e
+	ret
+
+.checkFirstNan:
+	ex	de, hl
+	push	hl
+	ld	hl, 07FFFFFh
+	add	hl, de
+	pop	hl
+	ex	de, hl
+	ret	nc
+	dec	e
+	inc	sp
+	inc	sp
+	inc	sp
+.outputNan:
+	; Carry is always set here
+	rr	a ; Z = 0, S = 1
+	rla	; Restore A
+	ccf	; C = 0
+	ret
+
+.checkBothNan:
+	ex	de, hl
+	push	hl
+	ld	hl, 07FFFFFh
+	add	hl, de
+	jq	c, .gotFirstNan
+	sbc	hl, de
+	add	hl, bc
+.gotFirstNan:
+	pop	hl
+	ex	de, hl
+	jq	nc, .checkBothNanDone
+	jq	.outputNan

--- a/src/fpdiv.inc
+++ b/src/fpdiv.inc
@@ -23,7 +23,7 @@ __fpdiv: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	jq	z, .subnormal.divisor
 	jq	nc, .add
 	sub	a, d
-	ld	e, a
+	ld	c, a
 	sbc	a, a
 	jq	.continue
 
@@ -37,10 +37,6 @@ __fpdiv: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	pop	af, hl, de
 	or	a, 07Fh
 	ret
-
-.overflow:
-	ld	bc, 0800000h
-	jq	.return.bc
 
 .subnormal.divisor:
 	ex	(sp), hl
@@ -58,47 +54,50 @@ __fpdiv: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	ex	(sp), hl
 .add:
 	sub	a, d
-	ld	e, a
+	ld	c, a
 	sbc	a, a
 	inc	a
 .continue:
-	ld	d, a
-	pop	bc
-	add	hl, bc
+	ld	b, a
+	pop	de
+	ex	de, hl  ; uhl=UDE, ude=UHL
+	add	hl, de	; uhl=UHL+UDE
+	ex	de, hl	; ude=UHL+UDE, uhl=UHL
 	or	a, a
-	sbc	hl, bc
+	sbc	hl, de	; uhl=-UDE
+	ex	de, hl	; ude=-UDE, uhl=UHL+UDE
+	or	a, a
+	adc	hl, de	; uhl=UHL
 	jq	z, .dividend.zero
-	or	a, a
 .normalize.dividend.loop:
-	sbc	hl, bc
-	jq	nc, .normalize.dividend.done
-	add	hl, bc
-	dec	de
+	add	hl, de
+	jq	c, .normalize.dividend.done
+	sbc	hl, de
+	dec	bc
 	add	hl, hl
 	jq	nc, .normalize.dividend.loop
-	or	a, a
-	sbc	hl, bc
+	add	hl, de
 .normalize.dividend.done:
-	dec	d
-	jq	z, .overflow
-	dec	de
-	ld	a, e
-	dec	de
-	inc	d
-	ex	de, hl
-	ld	hl, 1
-	jq	z, .divide.entry
-	dec	a
-	cp	a, -24
-	jq	c, .underflow
-.subnormal:
-	add	hl, hl
-	inc	a
-	jq	nz, .subnormal
-	inc	a
-	jq	nc, .divide.entry
-	ex	de, hl
-	add	hl, bc
+	djnz	.no_overflow
+	ld	c, b
+	jq	.return.bc
+.no_overflow:
+	dec	bc
+	dec	bc
+	ld	a, c
+	inc	b
+	ld	bc, 0800000h or (23 shl 8)
+	jq	z, .divide.entry.normal
+	scf
+	adc	a, b
+	jq	nc, .underflow
+	ld	b, a
+	ld	a, c
+	push	iy
+	ld	iy, 0
+	jq	nz, .divide.entry.subnormal
+	dec	hl
+	add	hl, de
 	jq	.subsubnormal
 
 .nonfinite.1:
@@ -111,60 +110,57 @@ __fpdiv: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 
 .nonfinite.2:
 	pop	hl
-	or	a, a
-	sbc	hl, bc
-	jq	nz, .return.nan
-	inc	hl
-.underflow:
 	dec	hl
+	add	hl, bc
+	jq	c, .return.nan
+.underflow:
+	sbc	hl, hl
 .dividend.zero:
 	pop	af
 	and	a, 080h
 	jq	.return.hl
 
+.divide.entry.normal:
+	push	iy
+	ld	iyl, b
 .divide.loop:
+	add	iy, iy
 	add	hl, hl
 	jq	c, .divide.overflow
-	sbc	hl, bc
-	jq	nc, .divide.setbit
-	add	hl, bc
-	ex	de, hl
-	add	hl, hl
-	ex	de, hl
-	jq	nc, .divide.loop
+	add	hl, de
+	jq	c, .divide.setbit
+	sbc	hl, de
+	djnz	.divide.loop
 	add	hl, hl
 	jq	.divide.finish
 .divide.overflow:
-	or	a, a
-	sbc	hl, bc
+	add	hl, de
 .divide.setbit:
-	ex	de, hl
-.divide.entry:
+.divide.entry.subnormal:
+	inc	iy
+	djnz	.divide.loop
 	add	hl, hl
-	inc	hl
-	ex	de, hl
-	jq	nc, .divide.loop
-	add	hl, hl
-.subsubnormal:
 	inc	hl
 .divide.finish:
-	ccf
-	jq	nc, .round
-	sbc	hl, bc
+	jq	c, .round
+	dec	de
+	add	hl, de
 .round:
+	ccf
+.subsubnormal:
+	lea	de, iy
+	pop	iy
 	sbc	hl, hl
 	inc	hl
 	add	hl, de
-	ld	de, 0800000h
-	jq	nc, .rounded
-	add	hl, de
-	inc	a
-.rounded:
-	pop	bc
-	sla	b
+	pop	de
+	ld	e, a
+	adc	a, 1
+	sla	d
 	rra
-	jq	c, .return.hl
-	add	hl, de
+	srl	e
+	jq	nc, .return.hl
+	add	hl, bc
 .return.hl:
 	ex	(sp), hl
 	pop	bc, de

--- a/src/fpdiv.inc
+++ b/src/fpdiv.inc
@@ -18,81 +18,57 @@ __fpdiv: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	jq	z, .nonfinite.2
 	add	a, 080h
 	dec	d
-	ld	d, a
-	ld	a, e
-	jq	z, .subnormal.divisor
-	jq	nc, .add
-	sub	a, d
-	ld	c, a
-	sbc	a, a
-	jq	.continue
-
-.divisor.zero:
-	pop	de
-	sbc	hl, de
-	jq	nz, .return.bc
-.return.nan:
-	set	7, b
-.return.bc:
-	pop	af, hl, de
-	or	a, 07Fh
-	ret
-
-.subnormal.divisor:
+	jq	nz, .exponent.adjust
 	ex	(sp), hl
 	add	hl, bc
 	jq	c, .normalize.divisor.done
 	sbc	hl, bc
 	jq	z, .divisor.zero
 .normalize.divisor.loop:
-	dec	d
+	dec	a
 	add	hl, hl
 	add	hl, bc
 	jq	nc, .normalize.divisor.loop
 .normalize.divisor.done:
 	add	hl, bc
 	ex	(sp), hl
-.add:
-	sub	a, d
+.exponent.adjust:
+	ex	de, hl	; ude=UHL, uhl=UDE
+	ld	h, b
+	rl	b
 	ld	c, a
-	sbc	a, a
-	inc	a
-.continue:
-	ld	b, a
-	pop	de
-	ex	de, hl  ; uhl=UDE, ude=UHL
+	sbc	hl, bc
+	ld	b, h
+	ld	c, l
+	pop	hl
 	add	hl, de	; uhl=UHL+UDE
 	ex	de, hl	; ude=UHL+UDE, uhl=UHL
-	or	a, a
+	xor	a, a
 	sbc	hl, de	; uhl=-UDE
 	ex	de, hl	; ude=-UDE, uhl=UHL+UDE
-	or	a, a
-	adc	hl, de	; uhl=UHL
-	jq	z, .dividend.zero
+	add	hl, de	; uhl=UHL
 .normalize.dividend.loop:
 	add	hl, de
 	jq	c, .normalize.dividend.done
 	sbc	hl, de
+	jq	z, .dividend.zero
 	dec	bc
 	add	hl, hl
 	jq	nc, .normalize.dividend.loop
 	add	hl, de
 .normalize.dividend.done:
-	djnz	.no_overflow
-	ld	c, b
-	jq	.return.bc
-.no_overflow:
+	cp	a, b
+	jq	nc, .return.overflow
 	dec	bc
 	dec	bc
 	ld	a, c
 	inc	b
 	ld	bc, 0800000h or (23 shl 8)
 	jq	z, .divide.entry.normal
-	scf
 	adc	a, b
-	jq	nc, .underflow
 	ld	b, a
 	ld	a, c
+	jq	nc, .return.underflow
 	push	iy
 	ld	iy, 0
 	jq	nz, .divide.entry.subnormal
@@ -100,25 +76,37 @@ __fpdiv: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	add	hl, de
 	jq	.subsubnormal
 
+.divisor.zero:
+	pop	de
+	sbc	hl, de
+	jq	nz, .return.nonfinite
+.return.nan:
+	inc	b
+.return.overflow:
+	ld	c, b
+.return.nonfinite:
+	pop	af, hl, de
+	or	a, 07Fh
+	ret
+
 .nonfinite.1:
 	inc	d
 	pop	de
 	jq	z, .return.nan
-	pop	af
-	or	a, 07Fh
-	jq	.return.hl
+	push	hl
+	pop	bc
+	jq	.return.nonfinite
 
 .nonfinite.2:
 	pop	hl
 	dec	hl
 	add	hl, bc
 	jq	c, .return.nan
-.underflow:
+.return.underflow:
 	sbc	hl, hl
 .dividend.zero:
-	pop	af
-	and	a, 080h
-	jq	.return.hl
+	pop	de
+	jq	.return
 
 .divide.entry.normal:
 	push	iy
@@ -156,12 +144,12 @@ __fpdiv: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	pop	de
 	ld	e, a
 	adc	a, 1
+	srl	e
+	jq	nc, .return
+	add	hl, bc
+.return:
 	sla	d
 	rra
-	srl	e
-	jq	nc, .return.hl
-	add	hl, bc
-.return.hl:
 	ex	(sp), hl
 	pop	bc, de
 	ret

--- a/src/fpdiv.inc
+++ b/src/fpdiv.inc
@@ -1,0 +1,171 @@
+; IEEE single precision division
+; aubc = aubc / euhl
+__fpdiv: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(float, pair8_24_t, { in.BC, in.A }) / bitcast(float, pair8_24_t, { in.HL, in.E })) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	de, hl
+	xor	a, e
+	push	af
+	xor	a, e
+	push	bc
+	call	__fpupop1
+	ex	(sp), hl
+	ld	d, e
+	ld	e, a
+	call	__fpupop2
+	inc	e
+	jq	z, .nonfinite.1
+	ld	a, d
+	inc	a
+	jq	z, .nonfinite.2
+	add	a, 080h
+	dec	d
+	ld	d, a
+	ld	a, e
+	jq	z, .subnormal.divisor
+	jq	nc, .add
+	sub	a, d
+	ld	e, a
+	sbc	a, a
+	jq	.continue
+
+.divisor.zero:
+	pop	de
+	sbc	hl, de
+	jq	nz, .return.bc
+.return.nan:
+	set	7, b
+.return.bc:
+	pop	af, hl, de
+	or	a, 07Fh
+	ret
+
+.overflow:
+	ld	bc, 0800000h
+	jq	.return.bc
+
+.subnormal.divisor:
+	ex	(sp), hl
+	add	hl, bc
+	jq	c, .normalize.divisor.done
+	sbc	hl, bc
+	jq	z, .divisor.zero
+.normalize.divisor.loop:
+	dec	d
+	add	hl, hl
+	add	hl, bc
+	jq	nc, .normalize.divisor.loop
+.normalize.divisor.done:
+	add	hl, bc
+	ex	(sp), hl
+.add:
+	sub	a, d
+	ld	e, a
+	sbc	a, a
+	inc	a
+.continue:
+	ld	d, a
+	pop	bc
+	add	hl, bc
+	or	a, a
+	sbc	hl, bc
+	jq	z, .dividend.zero
+	or	a, a
+.normalize.dividend.loop:
+	sbc	hl, bc
+	jq	nc, .normalize.dividend.done
+	add	hl, bc
+	dec	de
+	add	hl, hl
+	jq	nc, .normalize.dividend.loop
+	or	a, a
+	sbc	hl, bc
+.normalize.dividend.done:
+	dec	d
+	jq	z, .overflow
+	dec	de
+	ld	a, e
+	dec	de
+	inc	d
+	ex	de, hl
+	ld	hl, 1
+	jq	z, .divide.entry
+	dec	a
+	cp	a, -24
+	jq	c, .underflow
+.subnormal:
+	add	hl, hl
+	inc	a
+	jq	nz, .subnormal
+	inc	a
+	jq	nc, .divide.entry
+	ex	de, hl
+	add	hl, bc
+	jq	.subsubnormal
+
+.nonfinite.1:
+	inc	d
+	pop	de
+	jq	z, .return.nan
+	pop	af
+	or	a, 07Fh
+	jq	.return.hl
+
+.nonfinite.2:
+	pop	hl
+	or	a, a
+	sbc	hl, bc
+	jq	nz, .return.nan
+	inc	hl
+.underflow:
+	dec	hl
+.dividend.zero:
+	pop	af
+	and	a, 080h
+	jq	.return.hl
+
+.divide.loop:
+	add	hl, hl
+	jq	c, .divide.overflow
+	sbc	hl, bc
+	jq	nc, .divide.setbit
+	add	hl, bc
+	ex	de, hl
+	add	hl, hl
+	ex	de, hl
+	jq	nc, .divide.loop
+	add	hl, hl
+	jq	.divide.finish
+.divide.overflow:
+	or	a, a
+	sbc	hl, bc
+.divide.setbit:
+	ex	de, hl
+.divide.entry:
+	add	hl, hl
+	inc	hl
+	ex	de, hl
+	jq	nc, .divide.loop
+	add	hl, hl
+.subsubnormal:
+	inc	hl
+.divide.finish:
+	ccf
+	jq	nc, .round
+	sbc	hl, bc
+.round:
+	sbc	hl, hl
+	inc	hl
+	add	hl, de
+	ld	de, 0800000h
+	jq	nc, .rounded
+	add	hl, de
+	inc	a
+.rounded:
+	pop	bc
+	sla	b
+	rra
+	jq	c, .return.hl
+	add	hl, de
+.return.hl:
+	ex	(sp), hl
+	pop	bc, de
+	ret

--- a/src/fpminmax.inc
+++ b/src/fpminmax.inc
@@ -27,7 +27,13 @@ __fpmax: ; CHECK: sameignzerosign(bitcast(float, pair8_24_t, { out.BC, out.A }),
 	; Carry into bit 31 is equivalent to carry XOR overflow
 	jq	nc, .nocarry
 	ret	po
-	jq	__fpmin.return
+;	jq	.return
+	virtual
+		jr	nc, $
+		load .jr_nc : byte from $$
+	end virtual
+	db	.jr_nc
 .nocarry:
 	ret	pe
+.return:
 	jq	__fpmin.return

--- a/src/fpminmax.inc
+++ b/src/fpminmax.inc
@@ -1,0 +1,33 @@
+; IEEE single precision minimum
+; aubc = fmin(aubc, euhl)
+__fpmin: ; CHECK: sameignzerosign(bitcast(float, pair8_24_t, { out.BC, out.A }), fminf(quiet(bitcast(float, pair8_24_t, { in.BC, in.A })), quiet(bitcast(float, pair8_24_t, { in.HL, in.E })))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	call	__fpcmpo
+	ret	p
+	jq	nc, __fpmax.unordered
+.return:
+	push	hl
+	pop	bc
+	ld	a, e
+	ret
+
+; IEEE single precision maximum
+; aubc = fmax(aubc, euhl)
+__fpmax: ; CHECK: sameignzerosign(bitcast(float, pair8_24_t, { out.BC, out.A }), fmaxf(quiet(bitcast(float, pair8_24_t, { in.BC, in.A })), quiet(bitcast(float, pair8_24_t, { in.HL, in.E })))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	call	__fpcmpo
+	ret	c
+	jq	p, __fpmin.return
+.unordered:
+	; Compare the low 31 bits (ignoring sign) and return the smaller one, which is non-NaN if either one is
+	sbc	hl, bc
+	ccf
+	sbc	a, e
+	add	hl, bc
+	ccf
+	adc	a, e
+	; Carry into bit 31 is equivalent to carry XOR overflow
+	jq	nc, .nocarry
+	ret	po
+	jq	__fpmin.return
+.nocarry:
+	ret	pe
+	jq	__fpmin.return

--- a/src/fpmul.inc
+++ b/src/fpmul.inc
@@ -89,23 +89,27 @@ __fpmul: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), bitcast(fl
 	ld	b, (ix + 15)
 	mlt	bc
 	add	hl, bc
-	ld	(ix + 4), hl
-	ld	c, (ix + 17)
 	cp	a, d
 	jq	nz, .normalized
+	ld	bc, (ix + 2)
+	pop	de
 .normalize:
-	lea	hl, ix + 5
-	srl	(hl)
-repeat 5
-	dec	hl
-	rr	(hl)
-end repeat
-	jr	nc, .flushed
-	ld	(hl), a
+	srl	h
+	rr	l
+	rr	b
+	rr	c
+	rr	d
+	rr	e
+	jq	nc, .flushed
+	ld	e, a
 .flushed:
 	inc	a
 	jq	nz, .normalize
+	push	de
+	ld	(ix + 2), bc
 .normalized:
+	ld	(ix + 4), hl
+	ld	c, (ix + 17)
 	pop	ix, hl
 	inc	sp
 	ld	b, a

--- a/src/fprem.inc
+++ b/src/fprem.inc
@@ -1,0 +1,67 @@
+; IEEE single precision remainder
+; aubc = fmod(aubc, euhl)
+__fprem: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), fmodf(bitcast(float, pair8_24_t, { in.BC, in.A }), bitcast(float, pair8_24_t, { in.HL, in.E }))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	de
+	ld	d, a
+	set	7, a	; aubc = -abs(AUBC)
+	set	7, e	; euhl = -abs(EUHL)
+	call	__fpcmpo	; abs(AUBC) <=> abs(EUHL)
+	jq	m, .notge	; !(abs(AUBC) >= abs(EUHL))
+	push	hl, bc
+	call	__fpupop1
+	ex	(sp), hl
+	ld	a, e
+	ld	e, d
+	call	__fpupop2
+	ld	b, a
+	cpl
+	inc	e
+	add	a, e	; Always sets carry, unless dividend non-finite
+	ld	e, d
+	ld	d, b
+	pop	bc
+	push	de
+	ex	de, hl
+	sbc	hl, hl
+	add	hl, bc
+	jq	nc, .nan	; Return if dividend non-finite or divisor zero
+	sbc	hl, hl
+	or	a, a
+	sbc	hl, bc
+	inc	hl
+	ex	de, hl
+	call	m, __iremu	; If divisor subnormal, modulo the mantissas
+	ld	b, a
+	inc	b
+.rem.compare:
+	add	hl, de
+	jq	c, .rem.norestore
+	sbc	hl, de
+.rem.norestore:
+	dec	b
+	jq	z, .rem.finish
+.rem.loop:
+	add	hl, hl
+	jq	nc, .rem.compare
+	add	hl, de
+	djnz	.rem.loop
+.rem.finish:
+	pop	bc
+	rlc	c
+	ld	de, 0800000h
+	xor	a, a
+	call	__fppack
+	ex	(sp), hl
+	pop	bc, de
+	ret
+
+.nan:
+	pop	hl, hl
+.notge:
+	ld	a, d
+	pop	de
+	ret	c	; abs(AUBC) < abs(EUHL)
+	ld	bc, 0C00000h
+	ld	a, 0FFh
+	ret
+

--- a/src/fpround.inc
+++ b/src/fpround.inc
@@ -1,0 +1,52 @@
+; IEEE single precision round
+; aubc = round(aubc)
+__fpround: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), roundf(bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	bc
+	ex	(sp), hl
+	add	hl, hl
+	ld	h, a
+	rla
+	sub	a, 07Fh - 1
+	jq	c, .return.zero
+	sub	a, 24
+	jq	nc, .return
+	push	bc
+	cpl
+	ld	c, a
+	ld	a, h
+	sbc	hl, hl
+	call	__ishl
+	ex	de, hl
+	ex	(sp), hl
+	or	a, a
+	sbc	hl, de
+	ex	(sp), hl
+	ex	de, hl
+	jq	pe, .overflow
+	jq	c, .no_overflow
+	inc	a
+;	jq	.overflow
+	virtual
+		jr	c, $
+		load .jr_c : byte from $$
+	end virtual
+	db	.jr_c
+.no_overflow:
+	add	hl, hl
+.overflow:
+	pop	bc
+	call	__iand
+	push	hl
+	pop	bc
+	ld	h, a
+.return:
+	ld	a, h
+	pop	hl
+	ret
+
+.return.zero:
+	ld	bc, 0
+	ld	a, h
+	and	a, 080h
+	pop	hl
+	ret

--- a/src/fpsqrt.inc
+++ b/src/fpsqrt.inc
@@ -83,9 +83,9 @@ __fpsqrt: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), (float)sq
 	ld	a, e
 	add	a, 07Fh / 4 + 1
 	; Check whether to round up (never round-to-even because a root with the lowest mantissa bit set must be irrational)
-	bit	7, l
+	inc	l
 	pop	hl, de
-	ret	z
+	ret	p
 	inc	bc	; This never overflows into the exponent field
 	ret
 

--- a/src/fpsqrt.inc
+++ b/src/fpsqrt.inc
@@ -1,0 +1,103 @@
+; IEEE single precision square root
+; aubc = sqrt(aubc)
+__fpsqrt: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), (float)sqrt(bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	de, bc
+	ex	(sp), hl
+	ld	e, a
+	call	__fpupop1
+	add	hl, bc
+	or	a, a
+	sbc	hl, bc
+	jq	z, .zero
+	rlca
+	jq	c, .nan
+	inc	e
+	jq	z, .nonfinite
+	push	hl
+	ex	(sp), ix
+	sbc	hl, hl
+	srl	e
+	jq	nc, .normalize.skip
+.normalize.loop:
+	add	ix, ix
+	adc	hl, hl
+.normalize.skip:
+	dec	e
+	add	ix, ix
+	adc	hl, hl
+	jq	z, .normalize.loop
+	push	de
+	xor	a, a
+	ex	de, hl
+	sbc	hl, hl
+	ld	c, a
+	ld	b, 25
+	; x in AUDEUIX, r in CUHL
+.root.loop:
+	ex	de, hl
+	; r += 1
+	inc	de	; sets bit 0 so never overflows
+	; x -= r << 24
+	sbc	hl, de
+	sbc	a, c
+	jq	nc, .root.onebit
+	; x += r << 24
+	add	hl, de
+	adc	a, c
+	; r -= 2
+	dec	de
+	dec	de
+.root.onebit:
+	; r += 1
+	inc	de
+	; x <<= 2
+	repeat	2
+	add	ix, ix
+	adc	hl, hl
+	rla
+	end repeat
+	ex	de, hl
+	; r <<= 1
+	add	hl, hl
+	rl	c	; clears carry
+	djnz	.root.loop
+	; Shift left by 5
+	ld	a, c
+	repeat	5
+	add	hl, hl
+	rla
+	end repeat
+	; Set the low exponent bit of the result
+	pop	de, ix
+	sra	e
+	rla
+	rrca
+	; Shift right by 8
+	push	af
+	inc	sp
+	push	hl
+	inc	sp
+	pop	bc
+	inc	sp
+	; Calculate the high exponent bits and unset sign bit
+	ld	a, e
+	add	a, 07Fh / 4 + 1
+	; Check whether to round up (never round-to-even because a root with the lowest mantissa bit set must be irrational)
+	bit	7, l
+	pop	hl, de
+	ret	z
+	inc	bc	; This never overflows into the exponent field
+	ret
+
+.nonfinite:
+	rrca
+.zero:
+	ex	(sp), hl
+	pop	bc, de
+	ret
+
+.nan:
+	sbc	a, a
+	set	7, b
+	pop	hl, de
+	ret

--- a/src/fptol.inc
+++ b/src/fptol.inc
@@ -1,7 +1,7 @@
 ; IEEE single precision to 32-bit integers
 ; aubc = long(aubc)
-__fptol: ; CHECK: (!(bitcast(float, pair8_24_t, { in.BC, in.A })-INT32_MIN > -1.0f && bitcast(float, pair8_24_t, { in.BC, in.A }) < (INT32_MAX/2+1)*2.0f) || bitcast(int32_t, pair8_24_t, { out.BC, out.A }) == (int32_t)bitcast(float, pair8_24_t, { in.BC, in.A })) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
-__fptoul: ; CHECK: (!(bitcast(float, pair8_24_t, { in.BC, in.A }) > -1.0f && bitcast(float, pair8_24_t, { in.BC, in.A }) < (UINT32_MAX/2+1)*2.0f) ||  bitcast(uint32_t, pair8_24_t, { out.BC, out.A }) == (uint32_t)bitcast(float, pair8_24_t, { in.BC, in.A })) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+__fptol: ; PREREQ: bitcast(float, pair8_24_t, { in.BC, in.A })-INT32_MIN > -1.0f && bitcast(float, pair8_24_t, { in.BC, in.A }) < (INT32_MAX/2+1)*2.0f CHECK: bitcast(int32_t, pair8_24_t, { out.BC, out.A }) == (int32_t)bitcast(float, pair8_24_t, { in.BC, in.A }) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+__fptoul: ; PREREQ: bitcast(float, pair8_24_t, { in.BC, in.A }) > -1.0f && bitcast(float, pair8_24_t, { in.BC, in.A }) < (UINT32_MAX/2+1)*2.0f CHECK: bitcast(uint32_t, pair8_24_t, { out.BC, out.A }) == (uint32_t)bitcast(float, pair8_24_t, { in.BC, in.A }) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
 	push	de, bc
 	ex	(sp), hl
 	ld	d, a

--- a/src/fptol.inc
+++ b/src/fptol.inc
@@ -1,0 +1,42 @@
+; IEEE single precision to 32-bit integers
+; aubc = long(aubc)
+__fptol: ; CHECK: (!(bitcast(float, pair8_24_t, { in.BC, in.A })-INT32_MIN > -1.0f && bitcast(float, pair8_24_t, { in.BC, in.A }) < (INT32_MAX/2+1)*2.0f) || bitcast(int32_t, pair8_24_t, { out.BC, out.A }) == (int32_t)bitcast(float, pair8_24_t, { in.BC, in.A })) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+__fptoul: ; CHECK: (!(bitcast(float, pair8_24_t, { in.BC, in.A }) > -1.0f && bitcast(float, pair8_24_t, { in.BC, in.A }) < (UINT32_MAX/2+1)*2.0f) ||  bitcast(uint32_t, pair8_24_t, { out.BC, out.A }) == (uint32_t)bitcast(float, pair8_24_t, { in.BC, in.A })) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	de, bc
+	ex	(sp), hl
+	ld	d, a
+	ld	e, a
+	call	__fpupop1
+	ld	a, e
+	sub	a, 07Fh
+	cp	a, 23 + 32
+	jq	nc, .return.zero
+	sub	a, 23 + 1
+	jq	nc, .left
+	cpl
+	ld	c, a
+	call	__ishru
+	xor	a, a
+	jq	.finish
+.left:
+	inc	a
+	ld	b, a
+	xor	a, a
+.loop:
+	add	hl, hl
+	rla
+	djnz	.loop
+.finish:
+	ld	e, a
+	bit	7, d
+	call	nz, __lneg
+	ld	a, e
+.return:
+	ex	(sp), hl
+	pop	bc, de
+	ret
+
+.return.zero:
+	xor	a, a
+	sbc	hl, hl
+	jq	.return

--- a/src/fptoll.inc
+++ b/src/fptoll.inc
@@ -1,0 +1,35 @@
+; IEEE single precision to 64-bit integers
+; bcudeuhl = longlong(euhl)
+__fptoll: ; PREREQ: bitcast(float, pair8_24_t, { in.HL, in.E })-INT64_MIN > -1.0f && bitcast(float, pair8_24_t, { in.HL, in.E }) < (INT64_MAX/2+1)*2.0f CHECK: bitcast(int64_t, tuple16_24_24_t, { out.HL, out.DE, out.BCS }) == (int64_t)bitcast(float, pair8_24_t, { in.HL, in.E }) && out.A == in.A && out.IX == in.IX && out.IY == in.IY
+__fptoull: ; PREREQ: bitcast(float, pair8_24_t, { in.HL, in.E }) > -1.0f && bitcast(float, pair8_24_t, { in.HL, in.E }) < (UINT64_MAX/2+1)*2.0f CHECK: bitcast(uint64_t, tuple16_24_24_t, { out.HL, out.DE, out.BCS }) == (uint64_t)bitcast(float, pair8_24_t, { in.HL, in.E }) && out.A == in.A && out.IX == in.IX && out.IY == in.IY
+	ld	d, a
+	push	de
+	call	__fpupop1
+	ld	a, e
+	ld	de, 0
+	sub	a, 07Fh
+	cp	a, 23 + 64
+	jq	nc, .return.zero
+	sub	a, 23 + 1
+	jq	nc, .left
+	cpl
+	ld	c, a
+	call	__ishru
+	ld	c, b
+	jq	.finish
+.left:
+	inc	a
+	push	af
+	inc	sp
+	call	__llshl
+	inc	sp
+	inc	sp
+.finish:
+	pop	af
+	ret	p
+	jq	__llneg
+
+.return.zero:
+	sbc	hl, hl
+	pop	af
+	ret

--- a/src/fptrunc.inc
+++ b/src/fptrunc.inc
@@ -1,0 +1,34 @@
+; IEEE single precision truncation
+; aubc = trunc(aubc)
+__fptrunc: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), truncf(bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	bc
+	ex	(sp), hl
+	add	hl, hl
+	ld	h, a
+	rla
+	sub	a, 07Fh
+	jq	c, .return.zero
+	sub	a, 24
+	jq	nc, .return
+	ld	l, c
+	cpl
+	ld	c, a
+	ld	a, l
+	push	hl
+	sbc	hl, hl
+	call	__ishl
+	ld	c, a
+	call	__iand
+	ex	(sp), hl
+	pop	bc
+.return:
+	ld	a, h
+	pop	hl
+	ret
+
+.return.zero:
+	ld	bc, 0
+	ld	a, h
+	and	a, 080h
+	pop	hl
+	ret

--- a/src/fptrunc.inc
+++ b/src/fptrunc.inc
@@ -1,3 +1,61 @@
+; IEEE single precision floor
+; aubc = floor(aubc)
+__fpfloor: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), floorf(bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	cp	a, 080h
+	jq	c, __fptrunc
+.roundup:
+	push	bc
+	ex	(sp), hl
+	adc	hl, hl
+	ld	h, a
+	rla
+	jq	z, .mantissa.zero
+	sub	a, 07Fh
+	jq	c, .return.one
+	add	a, -24
+	jq	c, .return
+	ld	l, c
+	cpl
+	ld	c, a
+	ld	a, l
+	push	hl
+	sbc	hl, hl
+	inc	hl
+	call	__ishl
+	ld	c, a
+	dec	hl
+	dec	bc
+	call	__ior
+	ld	bc, 1
+	add	hl, bc
+	ex	(sp), hl
+	ld	a, h
+	adc	a, b
+	ld	h, a
+	pop	bc
+.return:
+	ld	a, h
+	pop	hl
+	ret
+
+.mantissa.zero:
+	dec	a
+	cp	a, 07Fh - 1
+	jq	nc, .return
+.return.one:
+	ld	bc, 0800000h
+	ld	a, h
+	or	a, 07Fh shr 1
+	pop	hl
+	ret
+
+; IEEE single precision ceiling
+; aubc = ceil(aubc)
+__fpceil: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), ceilf(bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	rlca
+	rrca
+	jq	nc, __fpfloor.roundup
+
 ; IEEE single precision truncation
 ; aubc = trunc(aubc)
 __fptrunc: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), truncf(bitcast(float, pair8_24_t, { in.BC, in.A }))) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY

--- a/src/fptrunc.inc
+++ b/src/fptrunc.inc
@@ -12,27 +12,24 @@ __fpfloor: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), floorf(b
 	jq	z, .mantissa.zero
 	sub	a, 07Fh
 	jq	c, .return.one
-	add	a, -24
-	jq	c, .return
-	ld	l, c
+	sub	a, 24
+	jq	nc, .return
+	push	bc
 	cpl
 	ld	c, a
-	ld	a, l
-	push	hl
-	sbc	hl, hl
-	inc	hl
-	call	__ishl
-	ld	c, a
-	dec	hl
-	dec	bc
-	call	__ior
-	ld	bc, 1
-	add	hl, bc
-	ex	(sp), hl
 	ld	a, h
-	adc	a, b
-	ld	h, a
+	sbc	hl, hl
+	call	__ishl
+	ex	(sp), hl
 	pop	bc
+	dec	hl
+	call	__iand
+	or	a, a
+	sbc	hl, bc
+	sbc	a, -1
+	push	hl
+	pop	bc
+	ld	h, a
 .return:
 	ld	a, h
 	pop	hl

--- a/src/fputil.inc
+++ b/src/fputil.inc
@@ -66,16 +66,15 @@ __fppack2:
 	jq	nc, .normalize
 .normalized:
 	ld	a, b
-	push	ix
-	ex	(sp), hl
-	or	a, a
-	adc	hl, hl
-	pop	hl
+	add	ix, de
 	jq	nc, .rounded
-	jq	nz, .round
+	dec	ix
+	add	ix, de
+	jq	nc, .round
 	bit	0, l
 	jq	z, .rounded
 .round:
+	scf
 	adc	hl, de
 	adc	a, e
 .clear:

--- a/src/fputil.inc
+++ b/src/fputil.inc
@@ -44,15 +44,20 @@ __fppack:
 	ret
 
 .normalize.entry:
-	add	hl, de
 	add	a, a
+	adc	hl, hl
+	ret	m
+	ccf
+	jr	nz, .normalize.continue
+	ld	b, 1
 .normalize.loop:
 	adc	hl, hl
 	ret	m
+.normalize.continue:
 	djnz	.normalize.loop
 	add	hl, de
 	ret
-	
+
 __fppack2.normalize:
 	dec	b
 	call	nz, .loop

--- a/src/fputil.inc
+++ b/src/fputil.inc
@@ -11,13 +11,11 @@ __fpupop2:
 	ret
 
 __fppack.normalize:
-	add	a, a
-	adc	hl, hl
+	dec	b
+	call	nz, .entry
 __fppack:
 	add	hl, de
-	jq	c, .normalized
-	djnz	.normalize
-	add	hl, de
+	jq	nc, .normalize
 .normalized:
 	add	a, a
 	ld	a, b
@@ -45,14 +43,22 @@ __fppack:
 	ex	de, hl
 	ret
 
-__fppack2.normalize:
-	add	ix, ix
+.normalize.entry:
+	add	hl, de
+	add	a, a
+.normalize.loop:
 	adc	hl, hl
+	ret	m
+	djnz	.normalize.loop
+	add	hl, de
+	ret
+	
+__fppack2.normalize:
+	dec	b
+	call	nz, .loop
 __fppack2:
 	add	hl, de
-	jq	c, .normalized
-	djnz	.normalize
-	add	hl, de
+	jq	nc, .normalize
 .normalized:
 	ld	a, b
 	push	ix
@@ -82,4 +88,12 @@ __fppack2:
 	sla	c
 	rra
 	ex	de, hl
+	ret
+
+.normalize.loop:
+	add	ix, ix
+	adc	hl, hl
+	ret	m
+	djnz	.normalize.loop
+	add	hl, de
 	ret

--- a/src/fputil.inc
+++ b/src/fputil.inc
@@ -34,10 +34,12 @@ __fppack:
 	add	a, a
 	adc	hl, hl
 	ret	m
-	ccf
-	jr	nz, .normalize.continue
+	jq	nz, .normalize.continue
+	or	a, a
+	jq	nz, .normalize.continue
 	ld	b, 1
 .normalize.loop:
+	add	a, a
 	adc	hl, hl
 	ret	m
 .normalize.continue:

--- a/src/fputil.inc
+++ b/src/fputil.inc
@@ -1,15 +1,13 @@
 __fpupop1:
 	ld	bc, 0800000h
 __fpupop2:
+	sla	e
+	jq	z, .denormal
 	add	hl, bc
-	rl	e
-	add	hl, bc
-	jq	nz, .notdenormal
-	inc	e
-	ccf
-.notdenormal:
 	ret	nc
 	add	hl, bc
+.denormal:
+	inc	e
 	ret
 
 __fppack.normalize:

--- a/src/fputil.inc
+++ b/src/fputil.inc
@@ -17,30 +17,17 @@ __fppack:
 	add	hl, de
 	jq	nc, .normalize
 .normalized:
-	add	a, a
-	ld	a, b
-	jq	nc, .rounded
-	jq	nz, .round
-	bit	0, l
-	jq	z, .rounded
-.round:
+	rrc	l
+	rlc	l
+	adc	a, 07Fh
 	adc	hl, de
+	ld	a, b
 	adc	a, e
-	cp	a, 0FFh
-	jq	z, .infinite
-.clear:
-	add	hl, de
-	jq	nc, .clear
-.rounded:
 	srl	c
 	rra
-	ret	nc
+	srl	b
+	ret	c
 	add	hl, de
-	ret
-.infinite:
-	srl	c
-	rra
-	ex	de, hl
 	ret
 
 .normalize.entry:

--- a/src/lltofp.inc
+++ b/src/lltofp.inc
@@ -1,0 +1,51 @@
+; IEEE single precision from 64-bit integers
+; euhl = float(bcudeuhl)
+__lltofp: ; CHECK: same(bitcast(float, pair8_24_t, { out.HL, out.E }), (float)bitcast(int64_t, tuple16_24_24_t, { in.HL, in.DE, in.BCS })) && out.A == in.A && out.BC == in.BC && out.IX == in.IX && out.IY == in.IY
+	push	af, bc
+	ld	a, b
+	or	a, a
+	call	m, __llneg
+	jq	__ulltofp.enter
+
+__ulltofp: ; CHECK: same(bitcast(float, pair8_24_t, { out.HL, out.E }), (float)bitcast(uint64_t, tuple16_24_24_t, { in.HL, in.DE, in.BCS })) && out.A == in.A && out.BC == in.BC && out.IX == in.IX && out.IY == in.IY
+	push	af, bc
+	xor	a, a
+.enter:
+	inc	b
+	djnz	.upper
+	inc	c
+	dec	c
+	jq	z, .lower
+.upper:
+	push	bc
+	push	de
+	push	hl
+	ld	c, a
+	ld	a, l
+	or	a, h
+	inc	sp
+	inc	sp
+	pop	hl
+	pop	de
+	inc	sp
+	or	a, l
+	ld	l, a
+	ld	b, 07Fh + 63
+;	jq	.pack
+	virtual
+		jp	c, $
+		load .jp_c : byte from $$
+	end virtual
+	db	.jp_c
+.lower:
+	ld	c, a
+	ld	b, 07Fh + 47
+.pack:
+	ex	de, hl
+	push	de
+	ex	(sp), ix
+	ld	de, 0800000h
+	call	__fppack2
+	ld	e, a
+	pop	ix, bc, af
+	ret

--- a/src/ltofp.inc
+++ b/src/ltofp.inc
@@ -1,0 +1,38 @@
+; IEEE single precision from 32-bit integers
+; aubc = float(aubc)
+__ultofp: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), (float)bitcast(uint32_t, pair8_24_t, { in.BC, in.A })) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	af
+	xor	a, a
+;	jq	__ltofp.enter
+	virtual
+		jr	c, $
+		load .jr_c : byte from $$
+	end virtual
+	db	.jr_c
+
+__ltofp: ; CHECK: same(bitcast(float, pair8_24_t, { out.BC, out.A }), (float)bitcast(int32_t, pair8_24_t, { in.BC, in.A })) && out.DE == in.DE && out.HL == in.HL && out.IX == in.IX && out.IY == in.IY
+	push	af
+.enter:
+	rlca
+	inc	sp
+	push	bc
+	inc	sp
+	ex	(sp), hl
+	ld	b, c
+	ld	c, a
+	ld	a, b
+	push	de
+	jq	nc, .positive
+	add	hl, de
+	ex	de, hl
+	neg
+	sbc	hl, de
+.positive:
+	ld	de, 0800000h
+	ld	b, 07Fh + 31
+	call	__fppack
+	pop	de
+	ex	(sp), hl
+	pop	bc
+	inc	sp
+	ret

--- a/test/tester.c
+++ b/test/tester.c
@@ -36,7 +36,7 @@ typedef struct pair8_24 { uint32_t x : 24, y : 8; } pair8_24_t;
 typedef struct tuple16_24_24 { uint64_t x : 24, y : 24, z : 16; } tuple16_24_24_t;
 #define bitcast(dst, src, ...) ((union { src __src; dst __dst; }){ __VA_ARGS__ }.__dst)
 bool same(float x, float y) {
-  return (x == y && copysign(1.0f, x) == copysign(1.0f, y)) || (isnan(x) && isnan(y));
+  return (x == y && !signbit(x) == !signbit(y)) || (isnan(x) && isnan(y));
 }
 
 static bool prereq(eZ80registers_t in, uint8_t inStack[10][3]) {

--- a/test/tester.c
+++ b/test/tester.c
@@ -36,7 +36,7 @@ typedef struct pair8_24 { uint32_t x : 24, y : 8; } pair8_24_t;
 typedef struct tuple16_24_24 { uint64_t x : 24, y : 24, z : 16; } tuple16_24_24_t;
 #define bitcast(dst, src, ...) ((union { src __src; dst __dst; }){ __VA_ARGS__ }.__dst)
 bool same(float x, float y) {
-  return x == y || (isnan(x) && isnan(y));
+  return (x == y && copysign(1.0f, x) == copysign(1.0f, y)) || (isnan(x) && isnan(y));
 }
 
 static bool prereq(eZ80registers_t in, uint8_t inStack[10][3]) {

--- a/test/tester.c
+++ b/test/tester.c
@@ -35,8 +35,17 @@ static const uint8_t halt = 0166;
 typedef struct pair8_24 { uint32_t x : 24, y : 8; } pair8_24_t;
 typedef struct tuple16_24_24 { uint64_t x : 24, y : 24, z : 16; } tuple16_24_24_t;
 #define bitcast(dst, src, ...) ((union { src __src; dst __dst; }){ __VA_ARGS__ }.__dst)
+
 bool same(float x, float y) {
   return (x == y && !signbit(x) == !signbit(y)) || (isnan(x) && isnan(y));
+}
+
+bool sameignzerosign(float x, float y) {
+    return x == y || (isnan(x) && isnan(y));
+}
+
+float quiet(float x) {
+    return isnan(x) ? NAN : x;
 }
 
 static bool prereq(eZ80registers_t in, uint8_t inStack[10][3]) {


### PR DESCRIPTION
Before:
```
Testing __fpadd... 0.000000% failed in 400/684.169824/10041 cycles minimum/average/maximum
Testing __fpsub... 0.000000% failed in 428/711.970796/10068 cycles minimum/average/maximum
Testing __fpmul... 0.000000% failed in 426/1175.312003/6692 cycles minimum/average/maximum
```

After:
```
Testing __fpadd... 0.000000% failed in 394/553.900509/1357 cycles minimum/average/maximum
Testing __fpsub... 0.000000% failed in 422/581.954986/1436 cycles minimum/average/maximum
Testing __fpmul... 0.000000% failed in 411/1138.370356/5766 cycles minimum/average/maximum
```